### PR TITLE
Add flag to disable automatic linking and initialization

### DIFF
--- a/src/RbInterpreter.cr
+++ b/src/RbInterpreter.cr
@@ -14,12 +14,19 @@ module Anyolite
     end
 
     def initialize
-      @rb_ptr = RbCore.rb_open
+      @rb_ptr = 
+      {% if flag?(:external_ruby) %}
+        Pointer(Anyolite::RbCore::State).null
+      {% else %}
+        RbCore.rb_open
+      {% end %}
       RbRefTable.set_current_interpreter(self)
     end
 
     def close
-      RbCore.rb_close(@rb_ptr)
+      {% unless flag?(:external_ruby) %}
+        RbCore.rb_close(@rb_ptr)
+      {% end %}
       RbRefTable.reset
       RbTypeCache.reset
       RbClassCache.reset

--- a/src/implementations/mri/RbCore.cr
+++ b/src/implementations/mri/RbCore.cr
@@ -21,7 +21,9 @@ module Anyolite
     {% end %}
   end
 
-  Anyolite.link_libraries
+  {% unless flag?(:external_ruby) %}
+    Anyolite.link_libraries
+  {% end %}
 
   lib RbCore
     alias RbFunc = Proc(RbInt, RbValue*, RbValue, RbValue) # argc, argv, self -> VALUE


### PR DESCRIPTION
When linked to external ruby, glue files are built manually as ruby extension and passed to linker using --link-flags

Related to https://forum.crystal-lang.org/t/embeddable-interoperable-with-ruby/4894/47