### PR TITLE
Working shards

### DIFF
--- a/install.cr
+++ b/install.cr
@@ -1,0 +1,1 @@
+system("rake build_shard")

--- a/install.cr
+++ b/install.cr
@@ -1,6 +1,6 @@
 {% if flag?(:win32) %}
   # TODO: Is there a better solution?
-  system("start /B rake build_shard && exit")
+  system("cmd /C rake build_shard && exit")
 {% else %}
   system("rake build_shard")
 {% end %}

--- a/install.cr
+++ b/install.cr
@@ -1,1 +1,1 @@
-system("rake build_shard")
+`rake build_shard`

--- a/install.cr
+++ b/install.cr
@@ -1,1 +1,5 @@
-`rake build_shard`
+{% if flag?(:win32) %}
+  system("cmd /k rake build_shard")
+{% else %}
+  system("rake build_shard")
+{% end %}

--- a/install.cr
+++ b/install.cr
@@ -1,5 +1,6 @@
 {% if flag?(:win32) %}
-  system("cmd /k rake build_shard && exit")
+  # TODO: Is there a better solution?
+  system("start /B rake build_shard && exit")
 {% else %}
   system("rake build_shard")
 {% end %}

--- a/install.cr
+++ b/install.cr
@@ -1,5 +1,5 @@
 {% if flag?(:win32) %}
-  system("cmd /k rake build_shard")
+  system("cmd /k rake build_shard && exit")
 {% else %}
   system("rake build_shard")
 {% end %}

--- a/install.cr
+++ b/install.cr
@@ -1,6 +1,6 @@
 {% if flag?(:win32) %}
   # TODO: Is there a better solution?
-  system("cmd /C rake build_shard && exit")
+  system("cmd /C rake build_shard")
 {% else %}
   system("rake build_shard")
 {% end %}

--- a/shard.yml
+++ b/shard.yml
@@ -8,7 +8,7 @@ description: |
   A library which allows for binding crystal classes and methods to an embedded mruby interpreter.
 
 scripts:
-  postinstall: rake build_shard
+  postinstall: crystal run install.cr
 
 license: MIT
 


### PR DESCRIPTION
This is a temporary fix to allow for the use of `shards` on Windows, as long as the `postinstall` option is only able to make use of executables on Windows.